### PR TITLE
Google+はサービス終了しているのでシェアボタン削除

### DIFF
--- a/data/partials.yaml
+++ b/data/partials.yaml
@@ -45,9 +45,6 @@ updates:
       - identifier: hatena-bookmark
         name: はてなブックマーク
         url: 'http://b.hatena.ne.jp/append?{url}'
-      - identifier: google-plus
-        name: Google+
-        url: 'https://plus.google.com/share?url={url}&text={title}'
   tags:
     heading: タグ
 promo:

--- a/static/assets/styles/base.css
+++ b/static/assets/styles/base.css
@@ -233,10 +233,6 @@
     content: "\F082";
   }
 
-  .fab.google-plus::before {
-    content: "\F0D4";
-  }
-
   .fab.twitter::before {
     content: "\F099";
   }

--- a/static/assets/styles/updates.css
+++ b/static/assets/styles/updates.css
@@ -175,10 +175,6 @@
     background-size: 60%;
   }
 
-  article.post .share .google-plus {
-    color: #DE4D3B;
-  }
-
   main footer nav ul {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
タイトルの通りです。不要と考えます。